### PR TITLE
fix: preserve endpoint typing

### DIFF
--- a/src/core/endpoint.ts
+++ b/src/core/endpoint.ts
@@ -28,4 +28,4 @@ export type AnyEndpointDefinition = EndpointDefinition<any, any>;
 
 export const makeEndpoint = <TInput extends ZodTypeAny, TOutput extends ZodTypeAny>(
   definition: EndpointDefinition<TInput, TOutput>
-): AnyEndpointDefinition => definition;
+): EndpointDefinition<TInput, TOutput> => definition;


### PR DESCRIPTION
## Summary
- keep `makeEndpoint` returning its inferred `EndpointDefinition` so handler I/O types remain available to consumers

## Testing
- npm run test:unit

------
https://chatgpt.com/codex/tasks/task_e_68e18ad2a54c8320bbfeff5025c74944