### PR TITLE
Add runtime-generated CLI for endpoint registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ export default makeEndpoint({
 npm install
 npm run dev:rest     # Start REST + Swagger on :3000
 npm run dev:mcp      # Start MCP server (stdio transport)
+npm run dev:cli      # Launch the runtime-generated CLI
 ```
 
 ### REST Server
@@ -91,6 +92,18 @@ RIVETBENCH_MCP_TRANSPORT=tcp RIVETBENCH_MCP_PORT=3001 npm run dev:mcp
 ```
 
 The MCP server exposes all registered endpoints as MCP tools with automatic schema validation.
+
+### CLI
+
+The CLI inspects the endpoint registry at startup so that available commands always mirror the REST and MCP transports.
+
+```bash
+# List registered endpoints
+npm run dev:cli -- list
+
+# Invoke an endpoint with JSON input
+npm run dev:cli -- call echo --input '{"message":"Hello"}'
+```
 
 ---
 

--- a/docs/LESSONS_LEARNED.md
+++ b/docs/LESSONS_LEARNED.md
@@ -103,6 +103,29 @@ context.log.info('Info');      // Safe (FastMCP → stderr)
 
 ---
 
+### 4. Runtime CLI Generation (October 2025)
+
+**Problem**: REST and MCP transports offered runtime registry-driven discovery, but the CLI required manual wiring, creating drift.
+
+**Solution**: Build the CLI on top of the shared endpoint registry so commands are generated dynamically at startup, mirroring other transports.
+
+**Pattern**:
+```typescript
+const cli = createCli({ registry, config });
+await cli.run(['call', 'echo', '--input', '{"message":"hi"}']);
+```
+
+**Rationale**:
+- Maintains parity across transports without build steps
+- Reduces duplication by reusing validation + handlers
+- Keeps developer experience consistent for new endpoints
+
+**Guardrail Updates**:
+- Added CLI coverage to README quick start instructions
+- Reinforced runtime registry usage for new transports
+
+---
+
 ## Testing Patterns
 
 ### 1. BDD Tagging Workflow (October 2025)

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "build": "tsc --noEmit",
     "dev:rest": "tsx src/server/rest.ts",
     "dev:mcp": "tsx src/server/mcp.ts",
+    "dev:cli": "tsx src/cli/index.ts",
     "test": "vitest",
     "test:unit": "vitest run",
     "test:bdd": "NODE_OPTIONS='--import tsx/esm' cucumber-js test/features --import 'test/steps/*.ts' --tags 'not @wip'",

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,0 +1,179 @@
+import { EndpointRegistry } from '../core/registry.js';
+import type { ServerConfig } from '../config/index.js';
+import { EndpointNotFoundError, ValidationError, toRivetBenchError } from '../core/errors.js';
+
+export interface CliIoStreams {
+  stdout: NodeJS.WritableStream;
+  stderr: NodeJS.WritableStream;
+}
+
+export interface CreateCliOptions {
+  registry: EndpointRegistry;
+  config: ServerConfig;
+  streams?: Partial<CliIoStreams>;
+}
+
+const usageText = (applicationName: string) => `\
+${applicationName} CLI\n\n` +
+`Usage:\n` +
+`  rivetbench list            List registered endpoints\n` +
+`  rivetbench call <name>    Invoke an endpoint with JSON input\n\n` +
+`Options:\n` +
+`  -i, --input <json>        JSON payload passed to the endpoint\n` +
+`  -h, --help                Show this help message\n`;
+
+const writeLine = (stream: NodeJS.WritableStream, message = '') => {
+  stream.write(`${message}\n`);
+};
+
+const handleList = (registry: EndpointRegistry, stdout: NodeJS.WritableStream) => {
+  const endpoints = registry.list();
+
+  if (endpoints.length === 0) {
+    writeLine(stdout, 'No endpoints registered.');
+    return;
+  }
+
+  for (const endpoint of endpoints) {
+    writeLine(stdout, `- ${endpoint.name}: ${endpoint.summary}`);
+  }
+};
+
+interface CallCommandArgs {
+  endpointName: string;
+  input: unknown;
+}
+
+const parseCallArgs = (args: string[]): CallCommandArgs => {
+  const [endpointName, ...rest] = args;
+
+  if (!endpointName) {
+    throw new ValidationError('Endpoint name is required for call command');
+  }
+
+  let rawInput = '{}';
+
+  for (let index = 0; index < rest.length; index += 1) {
+    const flag = rest[index];
+
+    if (flag === '--input' || flag === '-i') {
+      const value = rest[index + 1];
+
+      if (!value) {
+        throw new ValidationError('Missing value for input flag', { flag });
+      }
+
+      rawInput = value;
+      break;
+    }
+  }
+
+  try {
+    return { endpointName, input: JSON.parse(rawInput) };
+  } catch (error) {
+    throw new ValidationError('Invalid JSON input', { rawInput, cause: String(error) });
+  }
+};
+
+const handleCall = async (
+  registry: EndpointRegistry,
+  stdout: NodeJS.WritableStream,
+  args: string[]
+) => {
+  const { endpointName, input } = parseCallArgs(args);
+  const endpoint = registry.get(endpointName);
+
+  if (!endpoint) {
+    throw new EndpointNotFoundError(endpointName);
+  }
+
+  const parsedInput = endpoint.input.safeParse(input);
+
+  if (!parsedInput.success) {
+    throw new ValidationError('Invalid endpoint input', {
+      endpoint: endpointName,
+      issues: parsedInput.error.format()
+    });
+  }
+
+  const result = await endpoint.handler({
+    input: parsedInput.data,
+    config: { requestId: crypto.randomUUID() }
+  });
+
+  const parsedOutput = endpoint.output.parse(result);
+  writeLine(stdout, JSON.stringify(parsedOutput, null, 2));
+};
+
+/**
+ * Create a RivetBench command line interface that mirrors the runtime
+ * registry-driven behaviour used by the REST and MCP transports.
+ *
+ * @example
+ * ```ts
+ * import { loadConfig } from '../config/index.js';
+ * import { createDefaultRegistry } from '../endpoints/index.js';
+ * import { createCli } from './index.js';
+ *
+ * const config = loadConfig();
+ * const registry = createDefaultRegistry();
+ * const cli = createCli({ registry, config });
+ *
+ * await cli.run(['list']);
+ * ```
+ */
+export const createCli = ({ registry, config, streams }: CreateCliOptions) => {
+  const stdout = streams?.stdout ?? process.stdout;
+  const stderr = streams?.stderr ?? process.stderr;
+
+  const run = async (argv: string[]): Promise<number> => {
+    if (argv.length === 0 || argv.includes('--help') || argv.includes('-h')) {
+      writeLine(stdout, usageText(config.application.name));
+      return 0;
+    }
+
+    const [command, ...rest] = argv;
+
+    try {
+      if (command === 'list') {
+        handleList(registry, stdout);
+        return 0;
+      }
+
+      if (command === 'call') {
+        await handleCall(registry, stdout, rest);
+        return 0;
+      }
+
+      writeLine(stderr, `Unknown command: ${command}`);
+      writeLine(stderr, usageText(config.application.name));
+      return 1;
+    } catch (error) {
+      const rivetError = toRivetBenchError(error);
+      writeLine(stderr, JSON.stringify(rivetError.toJSON(), null, 2));
+      return 1;
+    }
+  };
+
+  return { run };
+};
+
+const isMainModule = process.argv[1]?.includes('cli');
+
+if (isMainModule) {
+  (async () => {
+    try {
+      const { loadConfig } = await import('../config/index.js');
+      const config = loadConfig();
+      const { createDefaultRegistry } = await import('../endpoints/index.js');
+      const registry = createDefaultRegistry();
+      const cli = createCli({ registry, config });
+      const exitCode = await cli.run(process.argv.slice(2));
+      process.exit(exitCode);
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.error('Failed to start CLI', error);
+      process.exit(1);
+    }
+  })();
+}

--- a/test/cli/index.test.ts
+++ b/test/cli/index.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest';
+import { Writable } from 'node:stream';
+import { loadConfig } from '../../src/config/index.js';
+import { createDefaultRegistry } from '../../src/endpoints/index.js';
+import { createCli } from '../../src/cli/index.js';
+
+const createMemoryStream = () => {
+  let buffer = '';
+
+  const stream = new Writable({
+    write(chunk, _encoding, callback) {
+      buffer += chunk.toString();
+      callback();
+    }
+  });
+
+  return {
+    stream,
+    read: () => buffer
+  };
+};
+
+describe('CLI', () => {
+  it('lists available endpoints', async () => {
+    const config = loadConfig();
+    const registry = createDefaultRegistry();
+    const stdout = createMemoryStream();
+    const cli = createCli({ registry, config, streams: { stdout: stdout.stream } });
+
+    const exitCode = await cli.run(['list']);
+
+    expect({ exitCode, output: stdout.read() }).toMatchObject({
+      exitCode: 0,
+      output: expect.stringContaining('echo')
+    });
+  });
+
+  it('invokes an endpoint with JSON input', async () => {
+    const config = loadConfig();
+    const registry = createDefaultRegistry();
+    const stdout = createMemoryStream();
+    const cli = createCli({ registry, config, streams: { stdout: stdout.stream } });
+
+    const exitCode = await cli.run(['call', 'echo', '--input', '{"message":"hi"}']);
+
+    expect({ exitCode, output: stdout.read().trim() }).toEqual({
+      exitCode: 0,
+      output: '{\n  "echoed": "hi"\n}'
+    });
+  });
+
+  it('returns an error for invalid endpoint input', async () => {
+    const config = loadConfig();
+    const registry = createDefaultRegistry();
+    const stderr = createMemoryStream();
+    const cli = createCli({ registry, config, streams: { stderr: stderr.stream } });
+
+    const exitCode = await cli.run(['call', 'echo', '--input', '{"message":""}']);
+
+    expect({ exitCode, error: JSON.parse(stderr.read()).error.code }).toEqual({
+      exitCode: 1,
+      error: 'VALIDATION_ERROR'
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add a CLI implementation that inspects the endpoint registry at runtime and mirrors REST/MCP behavior
- cover the CLI with unit tests and expose a dev:cli entry point
- document CLI usage and capture the runtime CLI pattern in lessons learned

## Testing
- npm run lint
- npm run type-check
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690ee143b4e88320a81f7d6fbd3c3f17)